### PR TITLE
Front end rewritten to be compatible with python 3 instead of python 2

### DIFF
--- a/src/frontend.py
+++ b/src/frontend.py
@@ -5,8 +5,8 @@
 
 
 
-from Tkinter import *
-import Tkinter as tk
+from tkinter import *
+import tkinter as tk
 import Tkconstants
 import tkFileDialog
 
@@ -24,7 +24,7 @@ class Application(tk.Frame):
     def get_filepath(self):
         # Note - you can only select CSV files right now
         self.filepath = tkFileDialog.askopenfilename(initialdir = "/",title = "Select data file",filetypes = (("csv files","*.csv"),("all files","*.*")))
-        print self.filepath
+        print(self.filepath)
         # future - once the file is selected, call back end analysis and then draw visualization onscreen
         # Backend calls go here
 

--- a/src/frontend.py
+++ b/src/frontend.py
@@ -3,13 +3,12 @@
 # Application : class - sets up and runs GUI commands
 # main() : initiate GUI code
 
-
+# Version 2 - trying to rewrite in python 3
 
 from tkinter import *
 import tkinter as tk
-import Tkconstants
-import tkFileDialog
-
+import tkinter.constants
+import tkinter.filedialog
 
 
 class Application(tk.Frame):


### PR DESCRIPTION
I did a few things to make the `frontend.py` file compatible with python 3 instead of python 2:
1. Tkinter [changed the import statements](http://python3porting.com/stdlib.html) in python 3 so those had to be rewritten.
1. Python 3 also changed the syntax for print statements so I fixed those as well.

Nothing else was changed. 